### PR TITLE
[#181382066] Remove consul validate

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,10 +79,3 @@
         line: "OOMScoreAdjust={{ _consul.oom_score_adj }}"
         insertafter: "^[Service]"
   when: _consul.oom_score_adj is defined and ansible_service_mgr == "systemd"
-
-- name: Validate configuration
-  command:
-    argv:
-      - consul
-      - validate
-      - "{{ _consul.config_dir }}"


### PR DESCRIPTION
Currently `consul validate` breaks because we do not pass argv to the validation. The additional work to keep this validate in sync with the various places where argv can be changed is not worth the earlier validation we get. When starting the consul service a validation is run as well.