### PR TITLE
[#181570422] Remove TXT records from DNS

### DIFF
--- a/templates/etc/consul.d/main.json.j2
+++ b/templates/etc/consul.d/main.json.j2
@@ -3,6 +3,9 @@
   "domain": "{{ _consul.domain }}",
   "data_dir": "{{ _consul.data_dir }}",
   "enable_local_script_checks": true,
+  "dns_config": {
+    "enable_additional_node_meta_txt": false
+  },
 {% if _consul.metadata is defined %}
   "node_meta": {
     {% for k,v in _consul.metadata.items() %}"{{ k }}": "{{ v }}"{% if not loop.last %},


### PR DESCRIPTION
TXT records are not needed right now and are causing haproxy memory issues.

https://www.consul.io/docs/agent/options#enable_additional_node_meta_txt