### PR TITLE
[#186577997] Update config files for Version 1.12

### DIFF
--- a/templates/etc/consul.d/main.json.j2
+++ b/templates/etc/consul.d/main.json.j2
@@ -18,7 +18,9 @@
   "raft_protocol": {{ _consul.raft_protocol }},
 {% endif %}
 {% if _consul.ui is defined %}
-  "ui": {{ _consul.ui  | lower }},
+  "ui_config": {
+    "enabled": {{ _consul.ui  | lower }}
+  },
 {% endif %}
   "enable_local_script_checks": true,
   "dns_config": {

--- a/templates/etc/consul.d/tls.json.j2
+++ b/templates/etc/consul.d/tls.json.j2
@@ -1,8 +1,14 @@
 {
-  "verify_outgoing": {{ _consul.crypto.tls.verify_outgoing|default("true") }},
-  "verify_server_hostname": {{ _consul.crypto.tls.verify_server_hostname|default("true") }},
-  "verify_incoming": {{ _consul.crypto.tls.verify_incoming|default("true") }},
-  "ca_file": "{{ _consul.crypto.tls.ca_file }}",
-  "cert_file": "{{ _consul.config_dir}}/{{ _consul.crypto.tls.cert_file }}",
-  "key_file": "{{ _consul.config_dir}}/{{ _consul.crypto.tls.key_file.name }}"
+  "tls": {
+    "defaults": {
+      "ca_file": "{{ _consul.crypto.tls.ca_file }}",
+      "cert_file": "{{ _consul.config_dir}}/{{ _consul.crypto.tls.cert_file }}",
+      "key_file": "{{ _consul.config_dir}}/{{ _consul.crypto.tls.key_file.name }}",
+      "verify_incoming": {{ _consul.crypto.tls.verify_incoming|default("true") }},
+      "verify_outgoing": {{ _consul.crypto.tls.verify_outgoing|default("true") }}
+      },
+    "internal_rpc": {
+      "verify_server_hostname": {{ _consul.crypto.tls.verify_server_hostname|default("true") }}
+      }
+  }
 }


### PR DESCRIPTION
- https://developer.hashicorp.com/consul/docs/upgrading/upgrade-specific#tls-configuration
- https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui
- https://github.com/hashicorp/consul/issues/17095 `verify_server_hostname` kann erst ab 1.17 in defaults verwendet werden